### PR TITLE
esbuild bug fixed; now works on windows

### DIFF
--- a/src/bundle/construct-manifest.ts
+++ b/src/bundle/construct-manifest.ts
@@ -40,6 +40,7 @@ ${routes
       )}"`
   )
   .join("\n")
+  // pathfix for windows (esbuild always uses windows backslash paths)
   .replace(/\\/g, "/")}
 
 const routeMapWithHandlers = {

--- a/src/bundle/construct-manifest.ts
+++ b/src/bundle/construct-manifest.ts
@@ -39,7 +39,8 @@ ${routes
         path.join(options.routesDirectory, relativePath)
       )}"`
   )
-  .join("\n")}
+  .join("\n")
+  .replace(/\\/g, "/")}
 
 const routeMapWithHandlers = {
   ${routes.map(({ id, route }) => `"${route}": ${id}.default`).join(",")}


### PR DESCRIPTION
I did some research and found out that esbuild uses unix based filepaths and found no way to change that behaviour, so I just modified the filepaths in the build step to always use unix based filepaths.

now the repo works for snippets but all the winterspec tests still fail for windows.

I'm working on the fix for the tests but you can merge this since it's more important