### PR TITLE
Implement winterspec2 route-types codegen

### DIFF
--- a/src/cli2/commands/codegen/route-types.ts
+++ b/src/cli2/commands/codegen/route-types.ts
@@ -1,8 +1,6 @@
-import { Command } from "commander"
 import fs from "node:fs/promises"
 import { BaseCommand } from "../../base-command.js"
-import { ResolvedWinterSpecConfig } from "src/config/utils.js"
-import { extractRouteSpecsFromAST } from "src/lib/codegen/extract-route-specs-from-ast.js"
+import { extractRouteSpecsFromAST } from "../../../lib/codegen/extract-route-specs-from-ast.js"
 import Debug from "debug"
 
 const debug = Debug("winterspec:CodeGenRouteTypes")
@@ -17,86 +15,66 @@ export class CodeGenRouteTypes extends BaseCommand {
       .option("--root <path>", "Path to your project root")
       .option("--tsconfig <path>", "Path to your tsconfig.json")
       .option("--routes-directory <path>", "Path to your routes directory")
-      .option("--platform <platform>", "The platform to bundle for")
       .action(async (options) => {
         debug("Running with config", options)
         const config = await this.loadConfig(options)
         debug("Config loaded.")
 
-        debug("Extracting route specs from AST...")
-        const { project, routes, renderType } = await extractRouteSpecsFromAST({
+        const { routes, renderType } = await extractRouteSpecsFromAST({
           tsConfigFilePath: config.tsconfigPath,
           routesDirectory: config.routesDirectory,
         })
-        debug("Route specs extracted.")
 
-        project.createSourceFile(
-          "manifest.ts",
-          `
-          import {z} from "zod"
+        const routeEntries = routes.map(
+          ({
+            route,
+            httpMethods,
+            jsonResponseZodOutputType,
+            jsonBodyZodInputType,
+            commonParamsZodInputType,
+            queryParamsZodInputType,
+            urlEncodedFormDataZodInputType,
+          }) => {
+            const parts = [
+              `route: "${route}"`,
+              `method: ${httpMethods.map((m) => `"${m}"`).join(" | ")}`,
+            ]
+            if (jsonResponseZodOutputType) {
+              parts.push(
+                `jsonResponse: ${renderType(jsonResponseZodOutputType)}`
+              )
+            }
+            if (jsonBodyZodInputType) {
+              parts.push(`jsonBody: ${renderType(jsonBodyZodInputType)}`)
+            }
+            if (commonParamsZodInputType) {
+              parts.push(
+                `commonParams: ${renderType(commonParamsZodInputType)}`
+              )
+            }
+            if (queryParamsZodInputType) {
+              parts.push(`queryParams: ${renderType(queryParamsZodInputType)}`)
+            }
+            if (urlEncodedFormDataZodInputType) {
+              parts.push(
+                `urlEncodedFormData: ${renderType(
+                  urlEncodedFormDataZodInputType
+                )}`
+              )
+            }
 
-          export type Routes = {
-    ${routes
-      .map(
-        ({
-          route,
-          httpMethods,
-          jsonResponseZodOutputType,
-          jsonBodyZodInputType,
-          commonParamsZodInputType,
-          queryParamsZodInputType,
-          urlEncodedFormDataZodInputType,
-        }) => {
-          return `  "${route}": {
-        route: "${route}"
-        method: ${httpMethods.map((m) => `"${m}"`).join(" | ")}
-        ${
-          jsonResponseZodOutputType
-            ? `jsonResponse: ${renderType(jsonResponseZodOutputType)}`
-            : ""
-        }
-        ${
-          jsonBodyZodInputType
-            ? `jsonBody: ${renderType(jsonBodyZodInputType)}`
-            : ""
-        }
-        ${
-          commonParamsZodInputType
-            ? `commonParams: ${renderType(commonParamsZodInputType)}`
-            : ""
-        }
-        ${
-          queryParamsZodInputType
-            ? `queryParams: ${renderType(queryParamsZodInputType)}`
-            : ""
-        }
-        ${
-          urlEncodedFormDataZodInputType
-            ? `urlEncodedFormData: ${renderType(
-                urlEncodedFormDataZodInputType
-              )}`
-            : ""
-        }
-      }`
-        }
-      )
-      .join("\n")}
-      }
-
-      type ExtractOrUnknown<T, Key extends string> = Key extends keyof T ? T[Key] : unknown;
-
-      export type RouteResponse<Path extends keyof Routes> = ExtractOrUnknown<Routes[Path], "jsonResponse">
-      export type RouteRequestBody<Path extends keyof Routes> = ExtractOrUnknown<Routes[Path], "jsonBody"> & ExtractOrUnknown<Routes[Path], "commonParams">
-      export type RouteRequestParams<Path extends keyof Routes> = ExtractOrUnknown<Routes[Path], "queryParams"> & ExtractOrUnknown<Routes[Path], "commonParams">
-      `
+            return `  "${route}": {\n    ${parts.join("\n    ")}\n  }`
+          }
         )
 
-        const result = project.emitToMemory({ emitOnlyDtsFiles: true })
-        await fs.writeFile(
-          options.output,
-          result.getFiles().find((f) => f.filePath.includes("/manifest.d.ts"))!
-            .text
-        )
+        const content =
+          `export type Routes = {\n${routeEntries.join("\n")}\n}\n\n` +
+          `type ExtractOrUnknown<T, Key extends string> = Key extends keyof T ? T[Key] : unknown\n\n` +
+          `export type RouteResponse<Path extends keyof Routes> = ExtractOrUnknown<Routes[Path], "jsonResponse">\n` +
+          `export type RouteRequestBody<Path extends keyof Routes> = ExtractOrUnknown<Routes[Path], "jsonBody"> & ExtractOrUnknown<Routes[Path], "commonParams">\n` +
+          `export type RouteRequestParams<Path extends keyof Routes> = ExtractOrUnknown<Routes[Path], "queryParams"> & ExtractOrUnknown<Routes[Path], "commonParams">\n`
+
+        await fs.writeFile(options.output, content)
       })
   }
 }

--- a/tests/cli/codegen/route-types2/api/foo.ts
+++ b/tests/cli/codegen/route-types2/api/foo.ts
@@ -1,0 +1,25 @@
+import { z } from "zod"
+import { withWinterSpec } from "../with-winter-spec.js"
+
+export const jsonResponse = z.object({
+  foo: z.object({
+    id: z.string().uuid(),
+    name: z.string(),
+  }),
+})
+
+export default withWinterSpec({
+  auth: "none",
+  methods: ["GET", "POST"],
+  jsonBody: z.object({
+    foo_id: z.string().uuid(),
+  }),
+  jsonResponse,
+})((req) => {
+  return Response.json({
+    foo: {
+      id: "example-id",
+      name: "foo",
+    },
+  })
+})

--- a/tests/cli/codegen/route-types2/api/importer.ts
+++ b/tests/cli/codegen/route-types2/api/importer.ts
@@ -1,0 +1,15 @@
+import { withWinterSpec } from "../with-winter-spec.js"
+import { jsonResponse } from "./foo.js"
+
+export default withWinterSpec({
+  auth: "none",
+  methods: ["PUT"],
+  jsonResponse,
+})((req) => {
+  return Response.json({
+    foo: {
+      id: "example-id",
+      name: "foo",
+    },
+  })
+})

--- a/tests/cli/codegen/route-types2/api/many-params.ts
+++ b/tests/cli/codegen/route-types2/api/many-params.ts
@@ -1,0 +1,35 @@
+import { z } from "zod"
+import { withWinterSpec } from "../with-winter-spec.js"
+
+const manyParams = z.object({
+  this_has: z.string(),
+  many: z.string(),
+  params: z.string(),
+  to: z.string(),
+  make: z.string(),
+  sure: z.string(),
+  type_is: z.string(),
+  fully: z.string(),
+  expanded: z.string(),
+})
+
+export default withWinterSpec({
+  auth: "none",
+  methods: ["GET", "POST"],
+  jsonBody: manyParams.extend({
+    and: manyParams,
+  }),
+  jsonResponse: z.object({
+    foo: z.object({
+      id: z.string().uuid(),
+      name: z.string(),
+    }),
+  }),
+})((req) => {
+  return Response.json({
+    foo: {
+      id: "example-id",
+      name: "foo",
+    },
+  })
+})

--- a/tests/cli/codegen/route-types2/api/param-transform.ts
+++ b/tests/cli/codegen/route-types2/api/param-transform.ts
@@ -1,0 +1,21 @@
+import { z } from "zod"
+import { withWinterSpec } from "../with-winter-spec.js"
+
+export default withWinterSpec({
+  auth: "none",
+  methods: ["GET", "POST"],
+  jsonBody: z.object({
+    // this should be written to route types as a string rather than a number
+    foo_id: z.string().transform((v) => Number(v)),
+  }),
+  jsonResponse: z.object({
+    ok: z.boolean(),
+  }),
+})((req) => {
+  return Response.json({
+    foo: {
+      id: "example-id",
+      name: "foo",
+    },
+  })
+})

--- a/tests/cli/codegen/route-types2/api/query-params.ts
+++ b/tests/cli/codegen/route-types2/api/query-params.ts
@@ -1,0 +1,12 @@
+import { z } from "zod"
+import { withWinterSpec } from "../with-winter-spec.js"
+
+export default withWinterSpec({
+  auth: "none",
+  methods: ["GET"],
+  queryParams: z.object({
+    foo_id: z.string().uuid(),
+  }),
+})((req) => {
+  return Response.json({})
+})

--- a/tests/cli/codegen/route-types2/api/union.ts
+++ b/tests/cli/codegen/route-types2/api/union.ts
@@ -1,0 +1,23 @@
+import { z } from "zod"
+import { withWinterSpec } from "../with-winter-spec.js"
+
+export default withWinterSpec({
+  auth: "none",
+  methods: ["GET", "POST"],
+  jsonBody: z.object({
+    foo_id: z.string().uuid(),
+  }),
+  jsonResponse: z.union([
+    z.object({
+      foo_id: z.string(),
+    }),
+    z.boolean().array(),
+  ]),
+})((req) => {
+  return Response.json({
+    foo: {
+      id: "example-id",
+      name: "foo",
+    },
+  })
+})

--- a/tests/cli/codegen/route-types2/route-type-codegen.test.ts
+++ b/tests/cli/codegen/route-types2/route-type-codegen.test.ts
@@ -1,0 +1,156 @@
+import test from "ava"
+import { getTestCLI2 } from "tests/fixtures/get-test-cli.js"
+import os from "node:os"
+import path from "node:path"
+import { randomUUID } from "node:crypto"
+import { fileURLToPath } from "node:url"
+import fs from "node:fs/promises"
+import { Project } from "ts-morph"
+
+test("CLI codegen route-types command produces the expected route types", async (t) => {
+  const cli = await getTestCLI2(t)
+
+  const testFileDirectory = path.dirname(fileURLToPath(import.meta.url))
+
+  const tempPath = path.join(os.tmpdir(), `${randomUUID()}.d.ts`)
+  const appDirectoryPath = path.join(testFileDirectory, "api")
+  const tsconfigPath = path.join(testFileDirectory, "tsconfig.json")
+  const execution = cli.executeCommand([
+    "codegen-route-types",
+    "-o",
+    tempPath,
+    "--routes-directory",
+    appDirectoryPath,
+    "--tsconfig",
+    tsconfigPath,
+  ])
+  const cliResult = await execution.waitUntilExit()
+  t.is(cliResult.exitCode, 0)
+
+  // Test created file
+  const routesDTs = await fs.readFile(tempPath, "utf-8")
+  t.log("Generated file:")
+  t.log(routesDTs)
+
+  const project = new Project({
+    compilerOptions: { strict: true },
+  })
+
+  project.createSourceFile("routes.ts", routesDTs)
+  project.createSourceFile(
+    "tests.ts",
+    `
+    import { expectTypeOf } from "expect-type"
+    import {Routes, RouteResponse, RouteRequestBody, RouteRequestParams} from "./routes"
+
+    type ExpectedRoutes = {
+      // Basic smoke test
+      "/foo": {
+        route: "/foo"
+        method: "GET" | "POST"
+        jsonResponse: {
+          foo: {
+            id: string
+            name: string
+          }
+        }
+        jsonBody: {
+          foo_id: string
+        }
+      }
+      // A route that imports part of its spec from /foo
+      "/importer": {
+        route: "/importer"
+        method: "PUT"
+        jsonResponse: {
+          foo: {
+            id: string
+            name: string
+          }
+        }
+      }
+      // Route that uses z.union
+      "/union": {
+        route: "/union"
+        method: "GET" | "POST"
+        jsonResponse: {
+          foo_id: string
+        } | boolean[]
+        jsonBody: {
+          foo_id: string
+        }
+      }
+      // Route with many parameters to make sure they're not truncated
+      "/many-params": {
+        route: "/many-params"
+        method: "GET" | "POST"
+        jsonResponse: {
+          foo: {
+            id: string
+            name: string
+          }
+        }
+        jsonBody: {
+          this_has: string
+          many: string
+          params: string
+          to: string
+          make: string
+          sure: string
+          type_is: string
+          fully: string
+          expanded: string
+          and: {
+            this_has: string
+            many: string
+            params: string
+            to: string
+            make: string
+            sure: string
+            type_is: string
+            fully: string
+            expanded: string
+          }
+        }
+      }
+      // Route that uses .transform()
+      "/param-transform": {
+        route: "/param-transform"
+        method: "GET" | "POST"
+        jsonResponse: {
+          ok: boolean
+        }
+        jsonBody: {
+          foo_id: string
+        }
+      }
+      // Query params
+      "/query-params": {
+        route: "/query-params"
+        method: "GET"
+        queryParams: {
+          foo_id: string
+        }
+      }
+    }
+
+    expectTypeOf<Routes>().toEqualTypeOf<ExpectedRoutes>()
+
+    expectTypeOf<RouteResponse<"/param-transform">>().toEqualTypeOf<{ok: boolean}>()
+    expectTypeOf<RouteRequestBody<"/param-transform">>().toEqualTypeOf<{foo_id: string}>()
+    expectTypeOf<RouteRequestParams<"/query-params">>().toEqualTypeOf<{foo_id: string}>()
+  `
+  )
+
+  const diagnostics = project.getPreEmitDiagnostics()
+
+  if (diagnostics.length > 0) {
+    t.log(project.formatDiagnosticsWithColorAndContext(diagnostics))
+
+    t.fail(
+      "Test TypeScript project using generated routes threw compile errors"
+    )
+  }
+
+  t.pass()
+})

--- a/tests/cli/codegen/route-types2/tsconfig.json
+++ b/tests/cli/codegen/route-types2/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "extends": "../../../../tsconfig.json",
+  "compilerOptions": {
+    "module": "ESNext",
+    "moduleResolution": "Bundler"
+  }
+}

--- a/tests/cli/codegen/route-types2/with-winter-spec.ts
+++ b/tests/cli/codegen/route-types2/with-winter-spec.ts
@@ -1,0 +1,10 @@
+import { createWithWinterSpec } from "../../../../src/index.js"
+
+export const withWinterSpec = createWithWinterSpec({
+  openapi: {
+    apiName: "hello-world",
+    productionServerUrl: "https://example.com",
+  },
+  authMiddleware: {},
+  beforeAuthMiddleware: [],
+})


### PR DESCRIPTION
## Summary
- implement simple `codegen-route-types` command for winterspec2
- add AVA test harness for winterspec2 route-types

## Testing
- `bun test tests/cli/codegen/route-types2/route-type-codegen.test.ts` *(fails: Test files must be run with the AVA CLI)*
- `bun x ava tests/cli/codegen/route-types2/route-type-codegen.test.ts`

------
https://chatgpt.com/codex/tasks/task_b_685967ea1314832e98f4dbcacc737882