### PR TITLE
Stop startDevServer2 from keeping esbuild alive

### DIFF
--- a/src/dev/dev-server2.ts
+++ b/src/dev/dev-server2.ts
@@ -32,7 +32,6 @@ export const startDevServer2 = async (options: StartDevServerOptions) => {
   const devBundlePath = path.join(tempDir, "dev-bundle.js")
 
   let server: http.Server | null = null
-  let buildContext: esbuild.BuildContext | null = null
   const mutableHttpHandler = {
     current: (_req, res) => {
       // This handler is used before the first build or if a build fails to produce a handler.
@@ -43,6 +42,10 @@ export const startDevServer2 = async (options: StartDevServerOptions) => {
 
   const ignore = await isGitIgnored({ cwd: rootDirectory })
 
+  let isBuilding = false
+  let rebuildScheduled = false
+  let manifestNeedsUpdate = true
+
   const updateManifest = async () => {
     const manifestContent = await constructManifest({
       routesDirectory: config.routesDirectory,
@@ -52,28 +55,25 @@ export const startDevServer2 = async (options: StartDevServerOptions) => {
     await fs.writeFile(manifestPath, manifestContent, "utf-8")
   }
 
-  const build = async () => {
+  const runSingleBuild = async () => {
     options.onBuildStart?.()
-    const buildStartedAt = performance.now()
-
     try {
-      if (!buildContext) {
+      if (manifestNeedsUpdate) {
         await updateManifest()
-        buildContext = await esbuild.context({
-          entryPoints: [manifestPath],
-          bundle: true,
-          platform: config.platform === "wintercg-minimal" ? "browser" : "node",
-          packages: config.platform === "node" ? "external" : undefined,
-          format: config.platform === "wintercg-minimal" ? "cjs" : "esm",
-          outfile: devBundlePath,
-          write: true,
-          sourcemap: "inline",
-          logLevel: "silent",
-        })
+        manifestNeedsUpdate = false
       }
 
-      const result = await buildContext.rebuild()
-      const durationMs = performance.now() - buildStartedAt
+      const result = await esbuild.build({
+        entryPoints: [manifestPath],
+        bundle: true,
+        platform: config.platform === "wintercg-minimal" ? "browser" : "node",
+        packages: config.platform === "node" ? "external" : undefined,
+        format: config.platform === "wintercg-minimal" ? "cjs" : "esm",
+        outfile: devBundlePath,
+        write: true,
+        sourcemap: "inline",
+        logLevel: "silent",
+      })
 
       if (result.errors.length === 0) {
         options.onBuildEnd?.({
@@ -190,7 +190,25 @@ export const startDevServer2 = async (options: StartDevServerOptions) => {
         errorMessage: err.message,
         buildUpdatedAtMs: Date.now(),
       })
+      // If the manifest update failed, try again on the next build.
+      manifestNeedsUpdate = true
     }
+  }
+
+  const build = async () => {
+    if (isBuilding) {
+      rebuildScheduled = true
+      return
+    }
+
+    isBuilding = true
+
+    do {
+      rebuildScheduled = false
+      await runSingleBuild()
+    } while (rebuildScheduled)
+
+    isBuilding = false
   }
 
   const watcher = new Watcher(rootDirectory, {
@@ -210,7 +228,7 @@ export const startDevServer2 = async (options: StartDevServerOptions) => {
 
   const handleFileChange = async (isManifestChange: boolean = false) => {
     if (isManifestChange) {
-      await updateManifest()
+      manifestNeedsUpdate = true
     }
     await build()
   }
@@ -229,9 +247,7 @@ export const startDevServer2 = async (options: StartDevServerOptions) => {
     await handleFileChange(true)
   })
 
-  // Initial build is triggered by watcher's ignoreInitial: false
-  // If ignoreInitial were true, you'd call:
-  await updateManifest()
+  // Initial build is triggered immediately.
   await build()
 
   const stop = async () => {
@@ -239,9 +255,7 @@ export const startDevServer2 = async (options: StartDevServerOptions) => {
     if (server) {
       await new Promise<void>((resolve) => server!.close(() => resolve()))
     }
-    if (buildContext) {
-      await buildContext.dispose()
-    }
+    esbuild.stop()
   }
 
   process.on("SIGINT", async () => {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,7 +9,8 @@
     "strict": true /* Enable all strict type-checking options. */,
     "skipLibCheck": true /* Skip type checking all .d.ts files. */,
     "paths": {
-      "src/*": ["./src/*"]
+      "src/*": ["./src/*"],
+      "winterspec": ["./src/index.ts"]
     },
     "resolveJsonModule": true,
     "rootDir": "./"


### PR DESCRIPTION
## Summary
- replace the persistent esbuild build context in `startDevServer2` with one-off builds and a queued rebuild loop so the dev server does not leave esbuild running between rebuilds
- ensure manifest regeneration is scheduled safely for future builds and always stop the esbuild service when the dev server shuts down
- map the `winterspec` module specifier in `tsconfig.json` so the type-checker resolves project imports during CI checks

## Testing
- `bunx tsc --noEmit`
- `bun run format`


------
https://chatgpt.com/codex/tasks/task_b_68d5c2c1e0ac832e9e8bfc1802958cf2