### PR TITLE
fix: normalize adapter middleware responses

### DIFF
--- a/src/serve/create-winter-spec-from-route-map.ts
+++ b/src/serve/create-winter-spec-from-route-map.ts
@@ -2,6 +2,7 @@ import { getRouteMatcher } from "next-route-matcher"
 import { normalizeRouteMap } from "../lib/normalize-route-map.js"
 import { WinterSpecRouteFn } from "src/types/web-handler.js"
 import {
+  MakeRequestOptions,
   WinterSpecRouteBundle,
   WinterSpecOptions,
   makeRequestAgainstWinterSpec,
@@ -24,8 +25,8 @@ export const createWinterSpecFromRouteMap = (
   const winterSpec = {
     routeMatcher,
     routeMapWithHandlers,
-    makeRequest: async (req: Request) =>
-      makeRequestAgainstWinterSpec(winterSpec)(req),
+    makeRequest: async (req: Request, opts?: MakeRequestOptions) =>
+      makeRequestAgainstWinterSpec(winterSpec, opts)(req),
     ...winterSpecOptions,
   }
 

--- a/src/types/winter-spec.ts
+++ b/src/types/winter-spec.ts
@@ -167,5 +167,7 @@ function serializeAdapterMiddlewareResponse(response: unknown): Response {
     )
   }
 
-  return response as Response
+  throw new Error(
+    "WinterSpec handlers must return a Response or ctx.json(...)."
+  )
 }

--- a/src/types/winter-spec.ts
+++ b/src/types/winter-spec.ts
@@ -1,10 +1,12 @@
 import type { Middleware } from "src/middleware/types.js"
 import {
   createWinterSpecRequest,
+  type SerializableToResponse,
   type WinterSpecRouteFn,
   type WinterSpecRouteParams,
   WinterSpecRequest,
 } from "./web-handler.js"
+import { z } from "zod"
 
 import type { ReadonlyDeep } from "type-fest"
 import { wrapMiddlewares } from "src/create-with-winter-spec.js"
@@ -123,14 +125,47 @@ export function makeRequestAgainstWinterSpec(
     })
 
     if (!routeFn) {
-      return await handle404(winterSpecRequest, getDefaultContext())
+      const response = await handle404(winterSpecRequest, getDefaultContext())
+      return serializeAdapterMiddlewareResponse(response)
     }
 
-    return wrapMiddlewares(
+    const response = await wrapMiddlewares(
       options.middleware ?? [],
       routeFn,
       winterSpecRequest,
       getDefaultContext()
     )
+
+    return serializeAdapterMiddlewareResponse(response)
   }
+}
+
+function canSerializeToResponse(
+  response: unknown
+): response is SerializableToResponse {
+  return (
+    response !== null &&
+    typeof response === "object" &&
+    "serializeToResponse" in response &&
+    typeof response.serializeToResponse === "function"
+  )
+}
+
+function serializeAdapterMiddlewareResponse(response: unknown): Response {
+  if (response instanceof Response) {
+    return response
+  }
+
+  // Adapter-level middleware runs outside route-specific serializers.
+  if (canSerializeToResponse(response)) {
+    return response.serializeToResponse(z.any())
+  }
+
+  if (typeof response === "object") {
+    throw new Error(
+      "Use ctx.json({...}) instead of returning an object directly."
+    )
+  }
+
+  return response as Response
 }

--- a/tests/errors/do-not-allow-raw-json.test.ts
+++ b/tests/errors/do-not-allow-raw-json.test.ts
@@ -1,5 +1,7 @@
 import test from "ava"
 import { z } from "zod"
+import { createWithWinterSpec } from "src/create-with-winter-spec.js"
+import { createWinterSpecFromRouteMap } from "src/serve/create-winter-spec-from-route-map.js"
 import { getTestRoute } from "tests/fixtures/get-test-route.js"
 
 test("should throw an error when responding with raw JSON", async (t) => {
@@ -36,4 +38,122 @@ test("should throw an error when responding with raw JSON", async (t) => {
       "Use ctx.json({...}) instead of returning an object directly"
     )
   )
+})
+
+test("should throw an error when adapter middleware responds with raw JSON", async (t) => {
+  const withRouteSpec = createWithWinterSpec({
+    authMiddleware: {},
+  })
+  const winterSpec = createWinterSpecFromRouteMap({
+    "/": withRouteSpec({
+      methods: ["GET"],
+      auth: "none",
+      jsonResponse: z.any(),
+    })((req, ctx) => {
+      return ctx.json({ ok: true })
+    }),
+  })
+  const makeRequest = (request: Request) =>
+    winterSpec.makeRequest(request, {
+      middleware: [
+        async () => {
+          return { foo: "bar" } as any
+        },
+      ],
+    })
+
+  const error = await t.throwsAsync(
+    makeRequest(new Request("https://example.com/"))
+  )
+  t.true(
+    error?.message.includes(
+      "Use ctx.json({...}) instead of returning an object directly."
+    )
+  )
+})
+
+test("should serialize ctx.json returned by adapter middleware", async (t) => {
+  const withRouteSpec = createWithWinterSpec({
+    authMiddleware: {},
+  })
+  const winterSpec = createWinterSpecFromRouteMap({
+    "/": withRouteSpec({
+      methods: ["GET"],
+      auth: "none",
+      jsonResponse: z.any(),
+    })((req, ctx) => {
+      return ctx.json({ ok: true })
+    }),
+  })
+  const response = await winterSpec.makeRequest(
+    new Request("https://example.com/"),
+    {
+      middleware: [
+        async (_req, ctx: any) => {
+          return ctx.json({ intercepted: true })
+        },
+      ],
+    }
+  )
+  t.true(response instanceof Response)
+  t.is(response.status, 200)
+  t.deepEqual(await response.json(), { intercepted: true })
+})
+
+test("should throw an error when handle404 responds with raw JSON", async (t) => {
+  const withRouteSpec = createWithWinterSpec({
+    authMiddleware: {},
+  })
+  const winterSpec = createWinterSpecFromRouteMap(
+    {
+      "/": withRouteSpec({
+        methods: ["GET"],
+        auth: "none",
+      })(() => {
+        return new Response("ok")
+      }),
+    },
+    {
+      handle404: () => {
+        return { error: "not found" } as any
+      },
+    }
+  )
+
+  const error = await t.throwsAsync(
+    winterSpec.makeRequest(new Request("https://example.com/missing"))
+  )
+  t.true(
+    error?.message.includes(
+      "Use ctx.json({...}) instead of returning an object directly."
+    )
+  )
+})
+
+test("should serialize ctx.json returned by handle404", async (t) => {
+  const withRouteSpec = createWithWinterSpec({
+    authMiddleware: {},
+  })
+  const winterSpec = createWinterSpecFromRouteMap(
+    {
+      "/": withRouteSpec({
+        methods: ["GET"],
+        auth: "none",
+      })(() => {
+        return new Response("ok")
+      }),
+    },
+    {
+      handle404: ((_req: any, ctx: any) => {
+        return ctx.json({ error: "not found" })
+      }) as any,
+    }
+  )
+
+  const response = await winterSpec.makeRequest(
+    new Request("https://example.com/missing")
+  )
+  t.true(response instanceof Response)
+  t.is(response.status, 200)
+  t.deepEqual(await response.json(), { error: "not found" })
 })

--- a/tests/errors/do-not-allow-raw-json.test.ts
+++ b/tests/errors/do-not-allow-raw-json.test.ts
@@ -100,6 +100,36 @@ test("should serialize ctx.json returned by adapter middleware", async (t) => {
   t.deepEqual(await response.json(), { intercepted: true })
 })
 
+test("should throw a helpful error when adapter middleware returns undefined", async (t) => {
+  const withRouteSpec = createWithWinterSpec({
+    authMiddleware: {},
+  })
+  const winterSpec = createWinterSpecFromRouteMap({
+    "/": withRouteSpec({
+      methods: ["GET"],
+      auth: "none",
+      jsonResponse: z.any(),
+    })((req, ctx) => {
+      return ctx.json({ ok: true })
+    }),
+  })
+
+  const error = await t.throwsAsync(
+    winterSpec.makeRequest(new Request("https://example.com/"), {
+      middleware: [
+        async () => {
+          return undefined as any
+        },
+      ],
+    })
+  )
+  t.true(
+    error?.message.includes(
+      "WinterSpec handlers must return a Response or ctx.json(...)."
+    )
+  )
+})
+
 test("should throw an error when handle404 responds with raw JSON", async (t) => {
   const withRouteSpec = createWithWinterSpec({
     authMiddleware: {},
@@ -156,4 +186,34 @@ test("should serialize ctx.json returned by handle404", async (t) => {
   t.true(response instanceof Response)
   t.is(response.status, 200)
   t.deepEqual(await response.json(), { error: "not found" })
+})
+
+test("should throw a helpful error when handle404 returns a primitive", async (t) => {
+  const withRouteSpec = createWithWinterSpec({
+    authMiddleware: {},
+  })
+  const winterSpec = createWinterSpecFromRouteMap(
+    {
+      "/": withRouteSpec({
+        methods: ["GET"],
+        auth: "none",
+      })(() => {
+        return new Response("ok")
+      }),
+    },
+    {
+      handle404: (() => {
+        return "not found"
+      }) as any,
+    }
+  )
+
+  const error = await t.throwsAsync(
+    winterSpec.makeRequest(new Request("https://example.com/missing"))
+  )
+  t.true(
+    error?.message.includes(
+      "WinterSpec handlers must return a Response or ctx.json(...)."
+    )
+  )
 })


### PR DESCRIPTION
## Summary
- Normalize responses returned by public makeRequest / adapter options.middleware.
- Thread makeRequest options through createWinterSpecFromRouteMap so the exported helper exercises the same middleware path.
- Normalize custom handle404 returns so raw JSON gets the existing guidance and ctx.json-style runtime returns become real Responses.
- Serialize ctx.json(...) / SerializableToResponse middleware short-circuits with z.any().
- Throw the existing raw JSON guidance when adapter middleware or handle404 returns a plain object.
- Throw a clear helper error when adapter middleware or handle404 returns unsupported primitives instead of passing invalid values through as Responses.
- Add focused regression coverage for adapter middleware and handle404 raw object / ctx.json / invalid return paths.

## Acceptance / contributor review
- Reviewed issue #30 acceptance surface: unsupported raw route-style returns should produce the actionable `ctx.json(...)` guidance instead of confusing serialization errors.
- Reviewed CONTRIBUTING.md: it asks contributors to run AVA for specific test files or `npm run test` for the full suite.
- Checked open PRs before submission for makeRequest/options.middleware and custom handle404 raw JSON / ctx.json paths; I did not find an overlapping open PR.

## Validation
- 2026-05-27 fresh check: `npx ava tests/errors/do-not-allow-raw-json.test.ts` -> 7 passed.
- Earlier check: `npx ava tests/errors/do-not-allow-raw-json.test.ts` -> 7 passed.
- Earlier check: `npx prettier --check src/types/winter-spec.ts tests/errors/do-not-allow-raw-json.test.ts` -> passed.
- Earlier check: `git diff --check` -> passed, with only the normal Windows LF-to-CRLF warning.
- `npx tsc --noEmit --pretty false` -> blocked by existing OpenAPI/codegen type errors in `src/cli/commands/codegen/openapi.ts`, `src/cli2/commands/codegen/openapi.ts`, and `tests/cli/codegen/openapi/openapi-codegen.test.ts`.
- `npm test -- tests/errors/do-not-allow-raw-json.test.ts` -> blocked during pretest build by the existing OpenAPI operation.responses errors above.

## Non-overlap check
Before submitting, I checked open PRs for makeRequestAgainstWinterSpec middleware, adapter middleware ctx.json, options.middleware raw object, handle404 ctx.json, and handle404 raw JSON. I did not find an open PR covering these public makeRequest/options.middleware or handle404 paths. PR #162 covers route/auth middleware inside createWithWinterSpec; this patch covers adapter-level middleware and custom 404 handlers passed through makeRequest/adapters.

/claim #30